### PR TITLE
Criar Mensagem de Commit

### DIFF
--- a/desafios.py
+++ b/desafios.py
@@ -35,14 +35,14 @@ def mostrar_mensagem_inicial():
 #     ]
 
 
-# def criar_mensagem_commit(funcao_nome):
-#     """
-#     Recebe o nome de uma função e retorna uma mensagem de commit padronizada.
-#     Exemplo:
-#     criar_mensagem_commit("listar_comandos_git_basicos") ->
-#     "Implementa função listar_comandos_git_basicos"
-#     """
-#     return f"Implementa função {funcao_nome}"
+def criar_mensagem_commit(funcao_nome):
+    """
+    Recebe o nome de uma função e retorna uma mensagem de commit padronizada.
+    Exemplo:
+    criar_mensagem_commit("listar_comandos_git_basicos") ->
+    "Implementa função listar_comandos_git_basicos"
+    """
+    return f"Implementa função {funcao_nome}"
 
 
 def verificar_tag_valida(tag):


### PR DESCRIPTION
Recebe o nome de uma função e retorna uma mensagem de commit padronizada.
    Exemplo:
    criar_mensagem_commit("listar_comandos_git_basicos") ->
    "Implementa função listar_comandos_git_basicos"